### PR TITLE
Use the host's /tmp, which should be big enough to extract the GOG in…

### DIFF
--- a/eu.vcmi.VCMI.yaml
+++ b/eu.vcmi.VCMI.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --device=all # gamepad and dri
+  - --filesystem=/tmp # use the host's /tmp, which should be big enough to extract the GOG installer there
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg


### PR DESCRIPTION
…staller there